### PR TITLE
Fix parse error for special characters that were encoded from single byte (e. g. non UTF) strings in PHP, probably fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ var phpUnserialize = require('phpunserialize');
 var foo = phpUnserialize('s:3:"foo";');
 ```
 
+Encoding
+--------
+PHP encodes UTF characters to string with length defined by number of bytes, not number of characters, therefore a string "$¢€𠜎" has a length of 10 instead of 4. phpUnserialize tries to mimic this behaviour. When such special characters were not encoded from UTF, but from some other 8-bit encoding (e.g. ISO-8859) the length of the string is correct and a string as "ščřž" would indeed have a length of 4. phpUnserialize would try to recreate UTF byte count and would come up with Parse error. I this case, just add true as a second parameter.PHP
+```javascript
+var foo = phpUnserialize('s:4:"ščřž";', true);
+```
+
 Running the Unit Tests
 ----------------------
 ```sh

--- a/phpUnserialize.js
+++ b/phpUnserialize.js
@@ -32,7 +32,7 @@
    * @param {String} phpstr Php serialized string to parse
    * @return {mixed} Parsed result
    */
-  return function (phpstr) {
+  return function (phpstr,singleByte) {
     var idx = 0
       , refStack = []
       , ridx = 0
@@ -84,7 +84,7 @@
             , val;
           while (bytes < len) {
             ch = phpstr.charCodeAt(idx + utfLen++);
-            if (ch <= 0x007F) {
+            if (ch <= 0x007F || singleByte) {
               bytes++;
             } else if (ch > 0x07FF) {
               bytes += 3;

--- a/spec/php-unserialize_spec.coffee
+++ b/spec/php-unserialize_spec.coffee
@@ -10,6 +10,8 @@ describe 'Php-serialize Suite', ->
         .toBe('$¢€𠜎')
       expect(phpUnserialize('s:10:"$¢€𠜎";'))
         .toBe('$¢€𠜎')
+      expect(phpUnserialize('s:15:"Ztráty a nálezy";',true))
+        .toBe('Ztráty a nálezy')
 
     it "can parse an integer", ->
       expect(phpUnserialize('i:1337;')).toBe(1337)


### PR DESCRIPTION
PHP encodes UTF characters to string with length defined by number of bytes, not number of characters, therefore a string "$¢€𠜎" has a length of 10 instead of 4. phpUnserialize tries to mimic this behaviour. When such special characters were not encoded from UTF, but from some other 8-bit encoding (e.g. ISO-8859) the length of the string is correct and a string as "ščřž" would indeed have a length of 4. phpUnserialize would try to recreate UTF byte count and would come up with Parse error.