### PR TITLE
fix: deserializing associate arrays that have keys starting with a number

### DIFF
--- a/phpUnserialize.js
+++ b/phpUnserialize.js
@@ -139,7 +139,7 @@
           for (i = 0; i < len; i++) {
             key = readKey();
             val = parseNext();
-            if (keep === resultArray && parseInt(key, 10) === i) {
+            if (keep === resultArray && key + '' === i + '') {
               // store in array version
               resultArray.push(val);
 


### PR DESCRIPTION
As the code is now an associative array with keys that start with a number were treated as indexes. ie:

```
$array = Array(
  "0b5f7j" => "value1",
  "anotherKey" => "value2"
);
```

This is because running `parseInt("0b5f7j")` results in "0" in JS.