### PR TITLE
Feat: non compliant strings parsing

### DIFF
--- a/phpUnserialize.js
+++ b/phpUnserialize.js
@@ -139,7 +139,7 @@
           for (i = 0; i < len; i++) {
             key = readKey();
             val = parseNext();
-            if (keep === resultArray && parseInt(key, 10) === i) {
+            if (keep === resultArray && key + '' === i + '') {
               // store in array version
               resultArray.push(val);
 

--- a/phpUnserialize.js
+++ b/phpUnserialize.js
@@ -92,6 +92,10 @@
               bytes += 2;
             }
           }
+          // catch non-compliant utf8 encodings
+          if (phpstr.charAt(idx + utfLen) !== '"') {
+            utfLen += phpstr.indexOf('"', idx + utfLen) - idx - utfLen;
+          }
           val = phpstr.substring(idx, idx + utfLen);
           idx += utfLen + 2;
           return val;


### PR DESCRIPTION
Sometimes PHP objects can contain strings that are not UTF8 compliant. This can cause problems when unserializing. An example of such a string:

`"searchTerm";s:28:"�f���V�����b�`�r�[�t�n���~�q";`

This is actually a Shift JIS encoded string. If we parse this currently the unserializer dies as the string length is not correct. PHP handles this correctly, at least it doesn't die, and gives a string with many question marks as a result.