### PR TITLE
fix: Only try to detect classes in string object keys

### DIFF
--- a/phpUnserialize.js
+++ b/phpUnserialize.js
@@ -174,7 +174,10 @@
           var class_name
             , prop_name
             , pos;
-          if ("\u0000" === parsedName.charAt(0)) {
+          if (
+            typeof parsedName === 'string' &&
+            "\u0000" === parsedName.charAt(0)
+          ) {
             // "<NUL>*<NUL>property"
             // "<NUL>class<NUL>property"
             pos = parsedName.indexOf("\u0000", 1);

--- a/phpUnserialize.spec.js
+++ b/phpUnserialize.spec.js
@@ -88,6 +88,12 @@ describe('Php-serialize Suite', () => {
       )).toEqual(expected);
     });
 
+    it('can parse a numeric key', () => {
+      expect(phpUnserialize(
+        'O:3:"key":2:{i:0;N;i:1;s:4:"main";}'
+      )).toEqual({ 0: null, 1: "main" });
+    });
+
     it('can parse a complex object', () => {
       expected = {
         bar : 1,


### PR DESCRIPTION
This allows us to parse an object like this; where the keys are not `string` values:
```js
{ 0: "something" }
```